### PR TITLE
Extract abstract from PLOS pages

### DIFF
--- a/scrapers/plos.json
+++ b/scrapers/plos.json
@@ -42,6 +42,10 @@
     "description": {
       "selector": "//meta[@name='description']",
       "attribute": "content"
+    },
+    "abstract":{
+      "selector": "//div[contains(@class, 'abstract')]",
+      "attribute": "text"
     }
   }
 }


### PR DESCRIPTION
We noticed that the `description` tag is actually taking the description of PLOS pages (i.e. PLOS as a journal) not the description of the article, so we extract the text from the abstract of the article itself.
(Greetings from #okfest14)
