### PR TITLE
Use Ruby Digest::MD5 instead of md5sum

### DIFF
--- a/scripts/make_tests.rb
+++ b/scripts/make_tests.rb
@@ -68,18 +68,9 @@ Dir.chdir('test') do
           results = JSON.load(File.open 'results.json')
           files = Dir['*']
           files = files.keep_if { |f| f != 'results.json' }
-          filehashes = `md5sum #{files.join(' ')}`
-          filehashes.split("\n").each do |line|
-            if line =~ /MD5 \(/
-              # OSX version of MD5
-              filename, filehash = /\((.*)\) = (\w+)/.match(line)[1, 2]
-            else
-              # linux version
-              filehash, filename = line.strip.split("  ")
-            end
-            results << { filename => filehash }
+          files.each do |f|
+            results << { f => Digest::MD5.file(f).hexdigest }
           end
-        end
         if (index + 1) < urls.length
           puts "waiting 15 seconds before next scrape"
           sleep(15)

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -67,11 +67,8 @@ Dir.chdir(tmpdir) do
         results = JSON.load(File.open 'results.json')
         files = Dir['*']
         files = files.keep_if { |f| f != 'results.json' }.map{ |f| f.strip }
-        cmd = "md5sum #{files.join(' ')}"
-        filehashes = `#{cmd}`
-        filehashes.split("\n").each do |line|
-          filehash, filename = line.strip.split("  ")
-          results << { filename => filehash }
+        files.each do |f|
+          results << { f => Digest::MD5.file(f).hexdigest }
         end
       end
       coverage_files << coverage(scraper, results)


### PR DESCRIPTION
The Ruby Digest::MD5 API is more consistent than trying to use the `md5sum` command line tool which has different names and response formats on different operating systems.
